### PR TITLE
Fix for class=[Object object] if className added TransitionGroup

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -173,7 +173,7 @@ export class TransitionGroup extends Component {
 				childrenToRender.push(el);
 			}
 		}
-
-		return createVNode(typeof component === 'string' ? 2 : 16, component, props, childrenToRender);
+		
+		return createVNode(typeof component === 'string' ? 2 : 16, component, props && props.className, childrenToRender, props);
 	}
 }


### PR DESCRIPTION
This is will fix  `class=[Object object]` if className added to `<TransitionGroup>` component